### PR TITLE
Remove extra tokens at end of #endif directives

### DIFF
--- a/ADXL345.cpp
+++ b/ADXL345.cpp
@@ -483,7 +483,7 @@ uint8_t ADXL345::fastRegister8(uint8_t reg)
         value = Wire.read();
     #else
         value = Wire.receive();
-    #endif;
+    #endif
     Wire.endTransmission();
 
     return value;
@@ -508,7 +508,7 @@ uint8_t ADXL345::readRegister8(uint8_t reg)
         value = Wire.read();
     #else
         value = Wire.receive();
-    #endif;
+    #endif
     Wire.endTransmission();
 
     return value;
@@ -535,7 +535,7 @@ int16_t ADXL345::readRegister16(uint8_t reg)
     #else
         uint8_t vla = Wire.receive();
         uint8_t vha = Wire.receive();
-    #endif;
+    #endif
     Wire.endTransmission();
 
     value = vha << 8 | vla;


### PR DESCRIPTION
Fix warnings caused by semicolons at the end of #endif directives.